### PR TITLE
Add reset() & save() to ConfigFile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ stages:
   - lint
   - test
 
-jobs:
+matrix:
   include:
     - stage: lint
       install:
@@ -12,13 +12,9 @@ jobs:
         - pre-commit install-hooks
       script:
         - pre-commit run --all-files
-
-matrix:
-  include:
-    - python: 3.8
+    - stage: test
+      python: 3.8
+      install: pip install --upgrade pip tox poetry
+      script: tox
       env:
         TOXENV: py38
-
-install: pip install --upgrade pip tox poetry
-
-script:	tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - stage: lint
       install:
         - pip install pre-commit
-        - pre-commit install-hooks
+        - pre-commit install
       script:
         - pre-commit run --all-files
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
 language: python
 
 stages:
-  - lint
   - test
 
 matrix:
   include:
-    - stage: lint
-      install:
-        - pip install pre-commit
-        - pre-commit install
-      script:
-        - pre-commit run --all-files
     - stage: test
       python: 3.8
       install: pip install --upgrade pip tox poetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+  - Change Travis CI to lint all files as well as run the tests.
+  - Add `reset()` and `save()` methods to `ConfigFile`. This allows you to reset your
+    configuration file to an "original state," given the original config file path. 
+    However, say you have a `config/config.json` file. Then it will automatically try 
+    to look for `config/config.original.json` if no file path is specified. The `save()`
+    method should be called after your changes to the config file. It will write them
+    back out.
+  - Raise test coverage to 93% (`BaseParser` is abstract so it isn't tested and some
+    methods in `ConfigFile` simply use the same method in the parser so it doesn't make
+    sense to test those methods.)
+
 ## 0.3.3
 
 Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,12 @@ Here are some guidelines to keep in mind when submitting a pull request:
   ```bash
     pre-commit install
   ```
-
-  If the pipeline is acting oddly, you can skip it with the ``--no-verify`` option 
-  to ``git push``.
+  
+- CI Pipeline: There is a CI pipeline that is run by Travis CI on commits to master and
+  on pull requests.
+  
+  - All it does is ensure that all the tests pass and that all the files adhere to the 
+    standard format (`pre-commit run --all-files`).
 
 To get started, make sure you have poetry installed and run ``poetry install`` and
 ``poetry shell`` to enter the virtual environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,7 @@ Here are some guidelines to keep in mind when submitting a pull request:
 - CI Pipeline: There is a CI pipeline that is run by Travis CI on commits to master and
   on pull requests.
   
-  - All it does is ensure that all the tests pass and that all the files adhere to the 
-    standard format (`pre-commit run --all-files`).
+  - All it does is ensure that all the tests pass.
 
 To get started, make sure you have poetry installed and run ``poetry install`` and
 ``poetry shell`` to enter the virtual environment.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@
 Config File allows you to use the same simple API for manipulating INI, JSON, 
 YAML, and TOML configuration files. For the time being, it only supports INI.
 
-## Motivation
-
-With applications I was building, I found myself frequently having to use some sort of configuration folder with an object that modeled the configuration file. I did this to help more easily manipulate my configuration. However, I found myself needing this sort of thing for several different applications and would end up rewriting something similar. So ended up deciding to create a package out of it so I could focus more on the application I was building instead.
-
-## Why not just use configparser, ConfigObj, etc.
-
-I wanted something a bit cleaner to use than configparser. The ini parser uses configparser under the hood, but it provides some niceties such as automatically parsing configuration values into their native types when you retrieve them. However, I also wanted something more flexible, and ini files aren't the only common configuration format. That is why Config File uses an adapter pattern to swap in and out the right parser for various file types you give it. This allows you to use the same API for all of your configuration needs. 
-
 ## Installation
 ```bash
 $ pip install config_file
@@ -91,5 +83,20 @@ config.has('calendar')
 config.has('week')
 >>> False
 config.has('calendar.start_week_on_sunday')
+>>> True
+
+# The file is only written back out when you call save()
+config.save()
+>>> True
+
+# You can also reset the file back to its original state. The current configuration file 
+# would be deleted and replaced by a copy of the original. By default, since our passed in
+# config file was at path `~/.config/test/config.ini`, `reset()` will look for 
+# `~/.config/test/config.original.ini`
+config.reset()
+>>> True
+
+# Or you can specify the file path explicitly
+config.reset(original_file_path="~/some_other_directory/this_is_actually_the_original.ini")
 >>> True
 ```

--- a/config_file/config_file.py
+++ b/config_file/config_file.py
@@ -1,5 +1,6 @@
 import inspect
-from pathlib import Path
+from pathlib import Path, PurePath
+from shutil import copyfile
 
 from config_file.parsers.base_parser import BaseParser
 from config_file.parsers.ini_parser import IniParser
@@ -7,26 +8,49 @@ from config_file.utils import split_on_dot
 
 
 class ConfigFile:
-    def __init__(self, file_path: str, parser=None):
+    def __init__(self, file_path, parser=None):
+        """
+        Saves the config file path and expands it if needed, reads in
+        the file contents, and determines what parser should be used for
+        the given file.
+
+        :param file_path: The path to your configuration file.
+        :param parser: A custom parser you'd like used for your config file.
+                      It must be a concrete implementation of BaseParser.
+
+        :raises ValueError: If the specified file path does not have an extension
+                            that is supported or it is a directory.
+        """
         self.path = self.__create_config_path(file_path)
-
-        with open(self.path, "r") as file:
-            self.contents = file.read()
-
+        self.contents = self.__read_config_file()
         self.parser = self.__determine_parser(file_path, parser)
 
     @staticmethod
-    def __create_config_path(file_path: str):
+    def __create_config_path(file_path, original=False) -> str:
+        if isinstance(file_path, PurePath):
+            file_path = str(file_path)
+
         if len(file_path) > 1 and file_path[0] == "~":
-            return Path(file_path).expanduser().resolve()
+            return str(Path(file_path).expanduser())
 
-        return Path(file_path)
+        if original:
+            file_parts = split_on_dot(file_path, only_last_dot=True)
+            file_parts.insert(-1, "original")
+            file_path = ".".join(file_parts)
 
-    def __determine_parser(self, file_path: str, parser):
+        if Path(file_path).is_dir():
+            raise ValueError(f"The specified config file ({file_path}) is a directory.")
+
+        return file_path
+
+    def __determine_parser(self, file_path, parser):
+        if isinstance(file_path, PurePath):
+            file_path = str(file_path)
+
         if isinstance(parser, BaseParser) and not inspect.isabstract(parser):
             return parser(self.contents)
 
-        file_type = split_on_dot(file_path)[-1]
+        file_type = split_on_dot(file_path, only_last_dot=True)[-1]
         if file_type == "ini":
             return IniParser(self.contents)
         else:
@@ -34,6 +58,10 @@ class ConfigFile:
                 f"File path contains an unsupported or "
                 f"unrecognized file type: {file_path}"
             )
+
+    def __read_config_file(self):
+        with open(self.path, "r") as file:
+            return file.read()
 
     def get(self, key, parse_type=True):
         """
@@ -64,6 +92,46 @@ class ConfigFile:
         using a section.key format.
 
         Some formats, like JSON, do not have sections and therefore,
-        it would only be checking if the section
+        it would only be checking if the key exists.
         """
         return self.parser.has(section_key)
+
+    def reset(self, original_file_path=None):
+        """
+        Resets the config file by deleting it and copying the original back
+        in its place. The contents of this config file are then set to the
+        newly reset config file.
+
+        :param original_file_path: The path to the original config file to reset it to.
+        If this is not provided and, say, your configuration file is config.json, the
+        method would look for a config.original.json in the same folder by default.
+
+        :return: True if the reset succeeded
+        :raises OSError: If the original configuration file is not present or if an
+                         error occurred when trying to copy the file.
+        """
+        if original_file_path is None:
+            original_file_path = self.__create_config_path(
+                str(self.path), original=True
+            )
+
+        if not Path(original_file_path).exists():
+            raise OSError(f"The {original_file_path} file to reset to does not exist.")
+
+        Path(self.path).expanduser().unlink(missing_ok=True)
+        copyfile(original_file_path, self.path)
+
+        self.contents = self.__read_config_file()
+        self.parser.parsed_content = self.parser.parse(self.contents)
+
+        return True
+
+    def save(self):
+        """
+        Save the configuration changes by writing the file out to the specified path
+        :return: True if the save succeeded.
+        """
+        with open(self.path, "w") as config_file:
+            config_file.write(self.parser.stringify())
+
+        return True

--- a/config_file/parsers/ini_parser.py
+++ b/config_file/parsers/ini_parser.py
@@ -33,6 +33,7 @@ class IniParser(BaseParser):
         :raises ParsingError: if the specified `section.key` is not found, in an
         invalid format, or if we are unable to coerce the return value to value_type.
         """
+        # TODO: Support for retrieving entire sections instead of just key/values
         section, key = split_on_dot(section_key, only_last_dot=True)
 
         try:

--- a/config_file/utils.py
+++ b/config_file/utils.py
@@ -8,6 +8,11 @@ def split_on_dot(line: str, only_last_dot=False):
     :raises ValueError: if the line does not have a dot.
     """
     if "." not in line:
+        # TODO: This is used in the parser for section.keys where a more specific
+        # error message would be nice, but it is only used more generically to, say,
+        # split a file path. We may just have to insert some try-catches to catch the
+        # ValueError and insert a more specific error message or create a custom error
+        # for this method?
         raise ValueError(
             "section_key must contain the section and key separated by a dot. "
             + "e.g. 'section.key'"

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import pytest
+
+from config_file.config_file import BaseParser, ConfigFile
+
+
+@pytest.mark.parametrize(
+    "file_contents, file_name", [("[calendar]\nsunday_index = 0\n\n", "config.ini")]
+)
+def test_that_config_file_initializes_correctly(tmp_path, file_contents, file_name):
+    temp = tmp_path / file_name
+    temp.write_text(file_contents)
+
+    config = ConfigFile(temp)
+    assert config.path == str(temp)
+    assert config.contents == temp.read_text()
+    assert isinstance(config.parser, BaseParser)
+
+
+@pytest.mark.parametrize(
+    "file_contents, file_name, original_file_name",
+    [("[calendar]\nsunday_index = 0\n\n", "config.ini", "config.original.ini")],
+)
+def test_that_config_file_can_reset(
+    tmpdir, file_contents, file_name, original_file_name
+):
+    config_path = tmpdir / file_name
+    config_path.write_text(file_contents, encoding="utf-8")
+
+    original_config_path = tmpdir / original_file_name
+    original_config_path.write_text(file_contents, encoding="utf-8")
+
+    config = ConfigFile(str(config_path))
+    config.set("calendar.sunday_index", 0)
+    config.reset()
+    assert config.stringify() == ConfigFile(str(original_config_path)).stringify()
+    assert config_path.read_text(encoding="utf-8") == original_config_path.read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.parametrize(
+    "file_contents, file_name", [("[calendar]\nsunday_index = 0\n\n", "config.ini")]
+)
+def test_that_config_file_can_save(tmpdir, file_contents, file_name):
+    config_path = tmpdir / file_name
+    config_path.write_text(file_contents, encoding="utf-8")
+
+    config = ConfigFile(str(config_path))
+    config.set("calendar.sunday_index", 1)
+    config.save()
+    assert config.stringify() == Path(config_path).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "path, is_dir", [("invalid", False), ("invalid", True), ("invalid.conf", False)]
+)
+def test_invalid_config_paths(tmpdir, path, is_dir):
+    with pytest.raises(ValueError):
+        temp_path = tmpdir / path
+        temp_path.write("")
+        ConfigFile(str(tmpdir)) if is_dir else ConfigFile(str(temp_path))

--- a/tests/test_ini_parser.py
+++ b/tests/test_ini_parser.py
@@ -35,17 +35,26 @@ floatkey = 5.3
 
 
 @pytest.mark.parametrize(
+    "test_input", ["invalid.invalid_key"],
+)
+def test_that_getting_unknown_sections_or_keys_throws_errors(test_input):
+    with pytest.raises(ParsingError):
+        IniParser("").get(test_input)
+
+
+@pytest.mark.parametrize(
     "section_key,value,expected_value",
     [
         ("test.key1", "different value", "[test]\nkey1 = different value\n\n"),
-        ("test.key2", 5, "[test]\nkey1 = different value\nkey2 = 5\n\n"),
-        ("test2.key", False, "[test]\nkey1 = value1\n[test2]\nkey = False\n\n"),
+        ("test.key2", 5, "[test]\nkey1 = value1\nkey2 = 5\n\n"),
+        ("test2.key", False, "[test]\nkey1 = value1\n\n[test2]\nkey = False\n\n"),
     ],
 )
 def test_that_ini_parser_can_set_values(section_key, value, expected_value):
     ini_file = """[test]\nkey1 = value1\n\n"""
     parser = IniParser(ini_file)
-    assert parser.stringify() == ini_file
+    parser.set(section_key, value)
+    assert parser.stringify() == expected_value
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parse_value.py
+++ b/tests/test_parse_value.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config_file.parsers.parse_value import parse_value
+from config_file.parsers.parse_value import can_be_parsed_as_bool, parse_value
 
 
 @pytest.mark.parametrize(
@@ -21,3 +21,12 @@ from config_file.parsers.parse_value import parse_value
 )
 def test_parse_value(test_input, expected):
     assert parse_value(test_input) == expected
+
+
+def test_can_be_parsed_as_bool():
+    """
+    This is the section not being covered in the parse_value.py
+    file from test_parse_value, but I don't think it's reachable
+    from using it.
+    """
+    assert can_be_parsed_as_bool(5) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+
+from config_file.utils import split_on_dot
+
+
+@pytest.mark.parametrize(
+    "test_input, only_last_dot, expected_result",
+    [("section.key.blah", False, ["section", "key", "blah"])],
+)
+def test_that_split_on_dot_splits_the_line_correctly(
+    test_input, only_last_dot, expected_result
+):
+    assert split_on_dot(test_input, only_last_dot=only_last_dot) == expected_result
+
+
+@pytest.mark.parametrize("test_input", ["this line has no dots in it"])
+def test_that_split_on_dot_raises_error_when_there_is_no_dot(test_input):
+    with pytest.raises(ValueError):
+        split_on_dot(test_input)


### PR DESCRIPTION
You could technically save by just using `stringify()`, but this provides a convenience method. `reset()` allows you to specify an original configuration file that you can reset to.